### PR TITLE
Add configuration option that disables default logging middleware

### DIFF
--- a/packages/travel-agent-server/src/__tests__/middleware/defaultMiddleware.spec.ts
+++ b/packages/travel-agent-server/src/__tests__/middleware/defaultMiddleware.spec.ts
@@ -120,8 +120,15 @@ describe("defaultMiddleware", () => {
     it("should return the dev middleware (without webpack)", () => {
       const middleware = defaultDevMiddleware({}, req);
       expect(middleware).toEqual([
-        "morgan-dev middleware",
         "express static middleware",
+        "morgan-dev middleware",
+      ]);
+    });
+
+    it("should not return morgan if logging is explicitly disabled", () => {
+      const middleware = defaultDevMiddleware({ disableDefaultLoggingMiddleware: true }, req);
+      expect(middleware).not.toContain([
+        "morgan-dev middleware",
       ]);
     });
 
@@ -136,8 +143,8 @@ describe("defaultMiddleware", () => {
         serverSideRender: true,
       });
       expect(middleware).toEqual([
-        "morgan-dev middleware",
         "express static middleware",
+        "morgan-dev middleware",
         "webpack-hot-middleware middleware",
         "webpack-dev-middleware middleware",
       ]);
@@ -151,8 +158,8 @@ describe("defaultMiddleware", () => {
     beforeEach(() => {
       expressBunyanLoggerMock = jest.fn(() => "express-bunyan-logger middleware")
       req = jest.fn<NodeRequire>()
-        .mockImplementationOnce((pkg: string) => expressBunyanLoggerMock)
-        .mockImplementationOnce((pkg: string) => () => "compression middleware");
+        .mockImplementationOnce((pkg: string) => () => "compression middleware")
+        .mockImplementationOnce((pkg: string) => expressBunyanLoggerMock);
       staticMock.mockImplementation((path: string) => "express static middleware");
     });
 
@@ -168,8 +175,16 @@ describe("defaultMiddleware", () => {
       expect(expressBunyanLoggerMock.mock.calls[0]).toMatchSnapshot();
       expect(middleware.length).toBe(2);
       expect(middleware).toEqual([
-        "express-bunyan-logger middleware",
         "compression middleware",
+        "express-bunyan-logger middleware",
+      ]);
+    });
+
+    it("should not return bunyan in production middleware if logging is disabled", () => {
+      const middleware = defaultProductionMiddleware({ disableDefaultLoggingMiddleware: true }, null, req);
+
+      expect(middleware).not.toContain([
+        "express-bunyan-logger middleware",
       ]);
     });
 
@@ -179,8 +194,8 @@ describe("defaultMiddleware", () => {
       expect(expressBunyanLoggerMock.mock.calls[0][0].name).toBe("lp-service-id");
       expect(middleware.length).toBe(3);
       expect(middleware).toEqual([
-        "express-bunyan-logger middleware",
         "compression middleware",
+        "express-bunyan-logger middleware",
         "express static middleware",
       ]);
     });

--- a/packages/travel-agent-server/src/classes/userConfigResolver.ts
+++ b/packages/travel-agent-server/src/classes/userConfigResolver.ts
@@ -29,6 +29,7 @@ export interface IUserConfig {
   sendProductionErrors?: boolean;
   production?: IUserConfig;
   serveAssets?: boolean;
+  disableDefaultLoggingMiddleware?: boolean;
 }
 
 export interface IUserConfigResolver {

--- a/packages/travel-agent-server/src/middleware/defaultMiddleware.ts
+++ b/packages/travel-agent-server/src/middleware/defaultMiddleware.ts
@@ -19,6 +19,10 @@ health.get("/health-check", (req, res) => {
   });
 });
 
+const shouldEnableDefaultLoggers = (options: IUserConfig) => {
+  return !options.disableDefaultLoggingMiddleware;
+};
+
 export const defaultMiddleware = (
   options?: IUserConfig,
   req: NodeRequire = require,
@@ -41,7 +45,7 @@ export const defaultDevMiddleware = (
     express.static(path.join(process.cwd(), "public")),
   ];
 
-  if (options.disableDefaultLoggingMiddleware !== true) {
+  if (shouldEnableDefaultLoggers(options)) {
     middleware.push(req("morgan")("dev"));
   }
 
@@ -80,7 +84,7 @@ export const defaultProductionMiddleware = (
     req("compression")(),
   ];
 
-  if (options.disableDefaultLoggingMiddleware !== true) {
+  if (shouldEnableDefaultLoggers(options)) {
     const excludes = [
       "body",
       "short-body",

--- a/packages/travel-agent-server/src/middleware/defaultMiddleware.ts
+++ b/packages/travel-agent-server/src/middleware/defaultMiddleware.ts
@@ -1,5 +1,6 @@
 /* tslint:disable: object-literal-sort-keys */
 import * as express from "express";
+import { Handler } from "express-serve-static-core";
 import * as path from "path";
 import * as AirbrakeClient from "airbrake-js";
 import * as makeErrorHandler from "airbrake-js/dist/instrumentation/express";
@@ -37,9 +38,12 @@ export const defaultDevMiddleware = (
   req: NodeRequire = require,
 ) => {
   const middleware = [
-    req("morgan")("dev"),
     express.static(path.join(process.cwd(), "public")),
   ];
+
+  if (options.disableDefaultLoggingMiddleware !== true) {
+    middleware.push(req("morgan")("dev"));
+  }
 
   if (options.webpack) {
     const webpack = req("webpack");
@@ -72,25 +76,28 @@ export const defaultProductionMiddleware = (
   name: string = process.env.LP_SERVICE_ID,
   req: NodeRequire = require,
 ) => {
-  const excludes = [
-    "body",
-    "short-body",
-    "req-headers",
-    "res-headers",
-    "req",
-    "res",
-    "incoming",
-    "response-hrtime",
+  const middleware = [
+    req("compression")(),
   ];
 
-  const middleware = [
-    req("express-bunyan-logger")({
+  if (options.disableDefaultLoggingMiddleware !== true) {
+    const excludes = [
+      "body",
+      "short-body",
+      "req-headers",
+      "res-headers",
+      "req",
+      "res",
+      "incoming",
+      "response-hrtime",
+    ];
+
+    middleware.push(req("express-bunyan-logger")({
       name: name || "travel-agent-server",
       parseUA: false, // Leave user-agent as raw string
       excludes,
-    }),
-    req("compression")(),
-  ];
+    }));
+  }
 
   if (options.serveAssets) {
     middleware.push(express.static(path.join(process.cwd(), "public")));


### PR DESCRIPTION
Added a new configuration option `disableDefaultLoggingMiddleware` that allow apps to disable default logging middleware and subsequently specify their own logging format. 

Closes #34 