### PR TITLE
log x-trace-token set on Fastly

### DIFF
--- a/packages/travel-agent-server/src/__tests__/middleware/__snapshots__/defaultMiddleware.spec.ts.snap
+++ b/packages/travel-agent-server/src/__tests__/middleware/__snapshots__/defaultMiddleware.spec.ts.snap
@@ -13,6 +13,7 @@ Array [
       "incoming",
       "response-hrtime",
     ],
+    "includesFn": [Function],
     "name": "travel-agent-server",
     "parseUA": false,
   },

--- a/packages/travel-agent-server/src/middleware/defaultMiddleware.ts
+++ b/packages/travel-agent-server/src/middleware/defaultMiddleware.ts
@@ -96,6 +96,7 @@ export const defaultProductionMiddleware = (
       req("express-bunyan-logger")({
         name: name || "travel-agent-server",
         parseUA: false, // Leave user-agent as raw string
+        includesFn: (req, res) => ({ 'x-trace-token': req.header('x-trace-token') }), // log x-trace-token set on Fastly
         excludes,
       }),
     );


### PR DESCRIPTION
Adds a new field to the logs so we can correlate entries with dispatch,
fastly and other services.